### PR TITLE
Added an example on how to add sensors to the web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ To add your own sensors to the web application, you need the following 3 items:
 
 There are 2 files that need to be changed to add the sensor to the portal.
 
-The first file is `fotaport\settings\defaults.py`. Find the data struct at the very bottom of the file that looks like the following:
+The first file is `wem\wem\settings\defaults.py`. Find the data struct at the very bottom of the file that looks like the following:
 
 ```
 MBED_CLOUD_PRESUBSCRIPTIONS = [


### PR DESCRIPTION
In response to WEM-12, the web application README needs at least one example to show how to modify the web application to exchange information with Mbed Cloud

This PR has an updated README which shows how to add a single sensor (with a corresponding chart) to the web app