### PR TITLE
Fix channel group send before add

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 asgi_redis==1.4.3
-asgi-ipc==1.4.1
+asgi-ipc==1.4.2
 asgiref==1.1.2
 asn1crypto==0.23.0
 attrs==17.2.0


### PR DESCRIPTION
If we start simulate_fake_device.py before loading the site in a browser,
manage.py runserver raises a bunch of exceptions.  This was fixed in
version 1.4.2 of asgi_ipc.  So upgrade to asgi_ipc 1.4.2.