### PR TITLE
request initial values when polling/webhook starts

### DIFF
--- a/livedevice/cloud_data_handlers.py
+++ b/livedevice/cloud_data_handlers.py
@@ -19,7 +19,7 @@ import re
 import json
 
 from channels import Group, Channel
-
+from django.core.cache import cache
 from .models import WebHookAuth, Sensor, Board
 
 logger = logging.getLogger(__name__)
@@ -47,9 +47,34 @@ def handle_data(webhook_auth, data):
         elif key == 'reg-updates':
             pass
         elif key == 'async-responses':
-            pass
+            handle_async_responses(webhook_auth, value)
         else:
             raise ValueError("unhandled cloud data type: %s" % key)
+
+
+def handle_async_responses(webhook_auth, async_responses):
+    """
+    Handle the 'async-responses' section of the webhook/polled data.
+
+    Args:
+        async_responses: content under 'async-responses', a list of
+        asynchronous responses.
+    """
+    for item in async_responses:
+        val = cache.get(item.get('id'))
+        if val is None:
+            print('Cache miss for ' + item.get('id'))
+            continue
+        path = val['path']
+        value = decode_payload(path, item['payload'])
+        message = {
+            'type': 'update',
+            'update': {
+                'board': val['ep'],
+                'sensor': path,
+                'value': value}}
+        send = NOTIFICATION_SENDERS.get(path, send_group)
+        send({'webhook_auth_id': webhook_auth.id, 'message': message})
 
 
 def handle_notifications(webhook_auth, notifications):

--- a/livedevice/mbedcloud.py
+++ b/livedevice/mbedcloud.py
@@ -55,9 +55,13 @@ class MBEDCloudSession(requests.Session):
             return
         if not (resource_path and resource_path.startswith('/')):
             return
+        print("Requesting " + "/v2/endpoints/%s%s" % (endpoint_id, resource_path))
         r = self.get("/v2/endpoints/%s%s" % (endpoint_id, resource_path))
-        r.raise_for_status()
-        return r.json()
+        try:
+            return r.json()
+        except ValueError as e:
+            print("Warn: %s does not have %s" % (endpoint_id, resource_path))
+            return {}
 
     """https://cloud.mbed.com/docs/v1.2/service-api-references/connect-api.html#notifications"""
     def get_callback(self):


### PR DESCRIPTION
To be more user-friendly, we request initial resource values from
mbed cloud. That way we can populate charts and such right away.

Signed-off-by: mbanders <michael.anderson@arm.com>